### PR TITLE
Allow anonymous checkout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Dependencies/MMTabBarView"]
 	path = Dependencies/MMTabBarView
-	url = git@github.com:adium/MMTabBarView.git
+	url = https://github.com/adium/MMTabBarView.git


### PR DESCRIPTION
Switch .gitmodules to HTTP references so the Project can be checked out
anonymously without GitHub Account.